### PR TITLE
Fixing bug with getSessionAndUser using an incorrect sk value.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -212,12 +212,12 @@ class DynamoDBAdapter1 implements Adapter {
     }));
     if (!sessionRes?.Items?.length) return [null, null];
     const session = this.itemToSession(sessionRes.Items[0]);
-  
+
     const userRes = await this.client.send(new GetItemCommand({
       TableName: this.tableName,
       Key: {
         [this.pk]: { S: `USER#${session.userId}` },
-        [this.sk]: { S: `USER#${session.userId}` },
+        [this.sk]: { S: `SESSION#${session.id}` },
       },
     }));
     if (!userRes?.Item) return [session, null];
@@ -523,12 +523,12 @@ class DynamoDBAdapter2 implements Adapter {
     }));
     if (!sessionRes?.Items?.length) return [null, null];
     const session = this.itemToSession(sessionRes.Items[0]);
-  
+
     const userRes = await this.client.send(new GetItemCommand({
       TableName: this.tableName,
       Key: {
         [this.pk]: { S: `USER#${session.userId}` },
-        [this.sk]: { S: `USER#${session.userId}` },
+        [this.sk]: { S: `SESSION#${session.id}` },
       },
     }));
     if (!userRes?.Item) return [session, null];


### PR DESCRIPTION
This PR fixes a bug where getSessionAndUser on both DynamoDBAdapter1 and DynamoDBAdapter2 are not successfully retrieving the user. Following is an explanation.

The setSession methods are doing this

```
[this.pk]: `USER#${databaseSession.userId}`,
[this.sk]: `SESSION#${databaseSession.id}`,
```

However in the getSessionAndUser function, when retrieving the user, the following is used

```
[this.pk]: { S: `USER#${session.userId}` },
[this.sk]: { S: `USER#${session.userId}` },
```

when it should be using

```
[this.pk]: { S: `USER#${session.userId}` },
[this.sk]: { S: `SESSION#${session.id}` },
```

