### PR TITLE
Feature/remove extra calls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -212,17 +212,7 @@ class DynamoDBAdapter1 implements Adapter {
     }));
     if (!sessionRes?.Items?.length) return [null, null];
     const session = this.itemToSession(sessionRes.Items[0]);
-
-    const userRes = await this.client.send(new GetItemCommand({
-      TableName: this.tableName,
-      Key: {
-        [this.pk]: { S: `USER#${session.userId}` },
-        [this.sk]: { S: `SESSION#${session.id}` },
-      },
-    }));
-    if (!userRes?.Item) return [session, null];
-    const user = this.itemToUser(userRes.Item);
-
+    const user = this.itemToUser(sessionRes.Items[0]);
     return [session, user];
   }
 
@@ -523,17 +513,7 @@ class DynamoDBAdapter2 implements Adapter {
     }));
     if (!sessionRes?.Items?.length) return [null, null];
     const session = this.itemToSession(sessionRes.Items[0]);
-
-    const userRes = await this.client.send(new GetItemCommand({
-      TableName: this.tableName,
-      Key: {
-        [this.pk]: { S: `USER#${session.userId}` },
-        [this.sk]: { S: `SESSION#${session.id}` },
-      },
-    }));
-    if (!userRes?.Item) return [session, null];
-    const user = this.itemToUser(userRes.Item);
-
+    const user = this.itemToUser(sessionRes.Items[0]);
     return [session, user];
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,12 +212,12 @@ class DynamoDBAdapter1 implements Adapter {
     }));
     if (!sessionRes?.Items?.length) return [null, null];
     const session = this.itemToSession(sessionRes.Items[0]);
-  
+
     const userRes = await this.client.send(new GetItemCommand({
       TableName: this.tableName,
       Key: {
         [this.pk]: { S: `USER#${session.userId}` },
-        [this.sk]: { S: `USER#${session.userId}` },
+        [this.sk]: { S: `SESSION#${session.id}` },
       },
     }));
     if (!userRes?.Item) return [session, null];
@@ -523,12 +523,12 @@ class DynamoDBAdapter2 implements Adapter {
     }));
     if (!sessionRes?.Items?.length) return [null, null];
     const session = this.itemToSession(sessionRes.Items[0]);
-  
+
     const userRes = await this.client.send(new GetItemCommand({
       TableName: this.tableName,
       Key: {
         [this.pk]: { S: `USER#${session.userId}` },
-        [this.sk]: { S: `USER#${session.userId}` },
+        [this.sk]: { S: `SESSION#${session.id}` },
       },
     }));
     if (!userRes?.Item) return [session, null];


### PR DESCRIPTION
The getSessionAndUser methods on DynamoDBAdapter1 and DynamoDBAdapter2 are making two calls to DynamoDB and only need to make one. I think it's reasonable to require ProjectionType set to all for the Gsi and you already have this in your README example. Removing this call cuts the potential costs associated with DynamoDB when using this adapter and it will improve performance.

